### PR TITLE
🐛 Fix NoneType AttributeError in Advanced Search

### DIFF
--- a/frontend/app/streamlit_app.py
+++ b/frontend/app/streamlit_app.py
@@ -375,7 +375,7 @@ else:
 if st.session_state.show_advanced:
     profile_payload = {
         "age":                      age,
-        "gender":                   gender.lower(),
+        "gender":                   gender.lower() if gender else None,
         "conditions":               [condition_input] if condition_input else [],
         "ecog":                     ecog,
         "biomarkers":               biomarkers,


### PR DESCRIPTION
Fixes a crash when submitting Advanced Search with no Gender selected by correctly checking for None before calling `.lower()`.